### PR TITLE
ShipNumberプラグイン3.0.14対応

### DIFF
--- a/Form/Extension/Admin/ShipNumberCollectionExtension.php
+++ b/Form/Extension/Admin/ShipNumberCollectionExtension.php
@@ -3,7 +3,7 @@
 * This file is part of EC-CUBE
 *
 * Copyright(c) 2015 Takashi Otaki All Rights Reserved.
-* 
+*
 *
 * For the full copyright and license information, please view the LICENSE
 * file that was distributed with this source code.
@@ -24,6 +24,7 @@ class ShipNumberCollectionExtension extends AbstractTypeExtension
             ->add('content', 'text', array(
                 'label' => '配送伝票番号',
                 'mapped' => false,
+                'required' => false,
             ))
       ;
     }


### PR DESCRIPTION
管理画面の受注管理で配送伝票番号欄への入力を任意とする

配送伝票番号が未確定などで空欄の時、他のフィールドの更新が確定できないため。
![2017-04-07 10 34 28](https://cloud.githubusercontent.com/assets/16634364/24781982/4dd31600-1b7e-11e7-8f39-df05214f95fa.png)
